### PR TITLE
INTERLOK-3555 Update the pom url to point to the right doc page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,7 +226,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Embedded ActiveMQ management component")
-        asNode().appendNode("url", "http://interlok.adaptris.net/interlok-docs/adapter-bootstrap.html#activemq-component")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/user-guide/adapter-bootstrap?id=activemq-component")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.6.0+")
         properties.appendNode("license", "false")


### PR DESCRIPTION
## Motivation

The documentation was broken since we changed the doc site

## Modification

Fix the doc url

## Result

The pom has a correct doc url

## Testing

Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.
