### PR TITLE
INTERLOK-2913 upgrade spring to 5.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 The suggested name was `bookish-barnacle`
 
-[http://interlok.adaptris.net/interlok-docs/adapter-bootstrap.html#activemq-component](http://interlok.adaptris.net/interlok-docs/adapter-bootstrap.html#activemq-component)
+[https://interlok.adaptris.net/interlok-docs/#/pages/user-guide/adapter-bootstrap?id=activemq-component](https://interlok.adaptris.net/interlok-docs/#/pages/user-guide/adapter-bootstrap?id=activemq-component)

--- a/build.gradle
+++ b/build.gradle
@@ -97,9 +97,9 @@ configurations.all {
 }
 
 dependencies {
-  compile ("com.adaptris:interlok-core:$interlokCoreVersion") { changing= true}
-  compile ("com.adaptris:interlok-common:$interlokCoreVersion") { changing= true}
-  compile ("org.apache.activemq:activemq-broker:$activeMqVersion")
+  compile  ("com.adaptris:interlok-core:$interlokCoreVersion") { changing= true}
+  compile  ("com.adaptris:interlok-common:$interlokCoreVersion") { changing= true}
+  compile  ("org.apache.activemq:activemq-broker:$activeMqVersion")
   compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion")
   compile ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
   compile ("com.google.guava:guava:30.1-jre")
@@ -157,6 +157,7 @@ sourceSets {
     output.dir(versionDir, builtBy: 'generateVersion')
   }
 }
+
 // Generate the META-INF/adaptris-version file
 task generateVersion {
   doLast {
@@ -164,9 +165,9 @@ task generateVersion {
     versionFile.getParentFile().mkdirs()
     ant.propertyfile(file: versionFile) {
       entry(key: 'component.name', value: componentName)
-      entry(key: 'build.version', value: releaseVersion)
       entry(key: 'groupId', value: "com.adaptris")
       entry(key: 'artifactId', value: project.name)
+      entry(key: 'build.version', value: releaseVersion)
       entry(key: 'build.date', value: new Date().format('yyyy-MM-dd'))
       entry(key: 'build.info', value: buildInfo())
     }
@@ -194,7 +195,7 @@ javadoc {
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet"]
     options.addStringOption "tagletpath", configurations.javadoc.asPath
-	options.addBooleanOption "-no-module-directories", true
+    options.addBooleanOption "-no-module-directories", true
     title= componentName
   }
 }
@@ -262,6 +263,7 @@ spotbugsMain {
     }
   }
 }
+
 dependencyCheck  {
   suppressionFiles= [ "https://raw.githubusercontent.com/adaptris/interlok/develop/gradle/owasp-exclude.xml", "$rootDir/gradle/owasp-exclude.xml" ]
   skipConfigurations = [ "antSql", "spotbugs", "umlDoclet", "offlineJavadocPackages", "javadoc", "jacocoAnt", "jacocoAgent", "spotbugsPlugins", "spotbugsSlf4j" ]

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ ext {
   organizationName = "Adaptris Ltd"
   organizationUrl = "http://interlok.adaptris.net"
   activeMqVersion="5.16.1"
-  springVersion="4.3.30.RELEASE"
+  springVersion="5.3.3"
   jacksonVersion="2.12.1"
   jacksonDatabindVersion = "2.12.1"
   slf4jVersion="1.7.30"
@@ -97,9 +97,9 @@ configurations.all {
 }
 
 dependencies {
-  compile  ("com.adaptris:interlok-core:$interlokCoreVersion") { changing= true}
-  compile  ("com.adaptris:interlok-common:$interlokCoreVersion") { changing= true}
-  compile  ("org.apache.activemq:activemq-broker:$activeMqVersion")
+  compile ("com.adaptris:interlok-core:$interlokCoreVersion") { changing= true}
+  compile ("com.adaptris:interlok-common:$interlokCoreVersion") { changing= true}
+  compile ("org.apache.activemq:activemq-broker:$activeMqVersion")
   compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion")
   compile ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
   compile ("com.google.guava:guava:30.1-jre")

--- a/src/test/java/com/adaptris/activemq/ActiveMQComponentTest.java
+++ b/src/test/java/com/adaptris/activemq/ActiveMQComponentTest.java
@@ -14,7 +14,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.commons.lang3.BooleanUtils;
 import org.junit.Test;
 
-import com.adaptris.core.BaseCase;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
 
 public class ActiveMQComponentTest {
 
@@ -29,9 +29,9 @@ public class ActiveMQComponentTest {
   private static final String MQTT = "tcp://127.0.0.1:1883";
 
   private static final String[] DEFAULT_PROTOCOLS =
-  {
-      OPENWIRE, AMQP, STOMP, MQTT
-  };
+    {
+        OPENWIRE, AMQP, STOMP, MQTT
+    };
 
   static {
     TEST_PROPERTIES = new Properties();


### PR DESCRIPTION
## Motivation

Use the latest spring version that integrates better with java11

## Modification

- Upgrade spring to 5.3.3
- Use non deprecated class for tests
- Update link doc in readme

## Result

Nothing should change on the usage of activemq

## Testing

The tests should still pass
Config using activemq should still work the same
