### PR TITLE
Bump springVersion from 5.3.23 to 5.3.26

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
   organizationName = "Adaptris Ltd"
   organizationUrl = "http://interlok.adaptris.net"
   activeMqVersion="5.17.2"
-  springVersion="5.3.23"
+  springVersion="5.3.26"
   jacksonVersion="2.14.2"
   slf4jVersion="2.0.3"
   mockitoVersion='4.8.0'


### PR DESCRIPTION
## Motivation

Updates org.springframework:spring-beans from 5.3.23 to 5.3.26
Updates org.springframework:spring-context from 5.3.23 to 5.3.26

## Modification

Bumps springVersion from 5.3.23 to 5.3.26.

## Result

Upgraded spring dependencies

## Testing

Build should pass